### PR TITLE
Adding work_contract.md for copying to individual repo and updated app.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -27,8 +27,13 @@ jumbotron = dbc.Jumbotron(
 
 row1 = dbc.Row(
                 [dbc.Col(
-                    html.H2("Placeholder text for intro", style={'color': 'black', 'fontSize': 20}),    
-                width=7)
+                    html.H2("The sinking of the Titanic four days into its maiden voyage on April 12, 1912 \
+                        as the world’s largest ocean liner is one of the worst maritime disasters of all time \
+                        which killed over 1,500 of the estimated 2,224 passengers and crew on board.\
+                        This app has been created to support an exploratory research proposal on the correlation \
+                        of passenger location with survival rates which may be used to improve and democratize \
+                        safety in the design of large passenger ships.", style={'color': 'black', 'fontSize': 20}),    
+                width=9)
                 ])
 
 #Rows for spacing between intro and viz

--- a/work_contract.md
+++ b/work_contract.md
@@ -1,0 +1,81 @@
+### Introduction
+
+To ensure an efficient, equitable and productive working environment aimed at delivering a high quality project, DSCI 532 Group 109 (“Group 109” or “Team”) of the University of British Columbia Master of Data Science program (“MDS”) has established a Team Work Contract (“Contract”) that provides a guideline for the individual and collective work tasks and responsibilities of its members (“Member”; collectively “Members” or “We”):  
+
+- Robert Blumberg
+- Trevor Kwan
+- George Thio  
+
+
+### Inspiration  
+
+![alt text](./img/post_it_notes.jpg)  
+
+The results of the first Team meeting on November 21, 2019 shown above capture the broad work principles unanimously agreed upon by the Team
+
+
+### Guidelines  
+
+We have grouped these work principles into the following four categories:  
+
+   1. Communications
+   2. Team Welfare and Equity
+   3. Flexibility
+   4. Responsibilities and Performance Standards
+
+#### Communications  
+
+- To ensure the project tasks are completed and deadlines are met in a timely manner, we agree to use any form of communication necessary including but not limited to Slack, email, text messaging, voice calls and GitHub Issues  
+
+- In order to consolidate important project related communications in GitHub Issues, but to avoid cluttering the repo with excessive ad-hoc banter, Members shall use their discretion to choose the appropriate form of communication  
+
+- GitHub Issues shall be used as the primary communication channel for any activities requiring a change in code and documentation
+
+- Upon creating a GitHub Issue or pull request (PR), a Member should immediately notify the Team on the Slack Channel after which the other Members shall adhere to the agreed upon response times specified below in 'Flexibility'
+
+- For all formal project contributions, Members shall push contributions to GitHub and make pull requests for another Member to approve and merge. Additionally, immediately before starting and immediately after ending any work on the app.py file, a Member shall create an Issue to inform the team and thereby reduce the chance of a potential merge conflict.
+
+- We do not place restrictions on the days of the week or time of day for ad-hoc communications within the Team, but mutually agree that under normal circumstances prompt responses should not be expected for communication initiated during the hours of 1:00-9:00 AM due to daily sleep schedules and morning routines
+
+
+#### Team Welfare and Equity  
+
+- We recognize that this project is first and foremost a valuable learning experience and as such seek to divide and assign work responsibilities not only to maximize productivity according to relative Member capabilities, but to also give each Member an opportunity to perform the different work tasks required to produce a successful project (e.g. Dash, Python/Altair, R/ggplot2, presentations)
+
+- For meetings, we agree to rotate the responsibility for setting agendas and taking, editing and pushing meeting notes to the project repo 
+
+- To accommodate unforeseen extenuating circumstances (e.g. personal/family emergencies) and protect the health and welfare of each Team member in good faith, the spirit rather than the letter of this Contract shall always prevail  
+
+
+#### Flexibility
+- We agree to be flexible on working hours and meeting venues and believe that an appropriate task-determined combination of in-person meetings, online meetings and independent individual work will maximize productivity and quality of the project
+
+
+- We agree that except in extenuating circumstances (e.g. personal/family emergencies), a minimum initial response time of four hours is expected for any Member requests of a non-urgent nature (i.e not related to a submission deadline on the same day)
+
+
+- We agree that except in extenuating circumstances (e.g. personal/family emergencies) to strive for a minimum initial response time of one hour for Member requests of an urgent  nature (i.e. related to a submission deadline on the same day)
+
+
+#### Responsibilities and Performance Standards  
+
+- This section is created to clearly and explicitly outline the division of work responsibilities to avoid any ambiguity, miscommunication of expectations, or degradation of performance
+
+
+- We agree to hold each other accountable to the highest standards of performance and ensure each Member is actively and meaningfully contributing to the goal of achieving an A+ grade for the project
+
+
+- To ensure the contributions of each Member are equitable with respect to quantity, quality and timeliness, the Team will hold a formal project review at the start of each weekly lab to discuss and immediately remedy any issues in this regard
+
+- As noted in 'Team Welfare and Equity', for the sake our personal development, we will strive to give each Member an opportunity to perform a variety of roles and responsibilities, but to avoid duplication, confusion and errors, the following 'gatekeeper' roles will assign each member primary responsibility for coordinating and delegating the tasks related to a specific part of the project:
+
+    *Rob*
+    Passenger location plot, Dash app coding, Heroku deployment, Github coordination, Peer feedback
+    
+    *Trevor*
+    Research-vis alignment, Proposal formulation and development, Survival Rate vs Class plot, Teaching staff liaison
+    
+    *George*
+    Code of Conduct, Work Contract, Contributing doc, Survival Rate vs Deck plot, Deck legend, General text editing 
+
+- As the [MDS general lab instructions](https://ubc-mds.github.io/resources_pages/general_lab_instructions/) form part of the project grading rubric and provide a useful foundation for the technical integrity of the project, we agree to individually and collectively adhere to these guidelines and hold each other accountable to this objective


### PR DESCRIPTION
1. Please review the updated work contract incorporating suggested changes, and if no further changes need to be made, you can save to your individual repos  and we can delete from the group repo

2. Have updated app.py with the text which displays fine since it is occupying almost the entire row width. I could add more (e.g. was going to discuss how popular the Titanic theme is with #3 all-time biggest movie and #9 all-time hit song) but I think it gets to the point.